### PR TITLE
chore: recommend npm-version-lens extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,19 +1,19 @@
 {
-    "recommendations": [
-        "esbenp.prettier-vscode",
-        "dbaeumer.vscode-eslint",
-        "drknoxy.eslint-disable-snippets",
-        "ms-python.black-formatter",
-        "aaron-bond.better-comments",
-        "ionutvmi.path-autocomplete",
-        "eamodio.gitlens",
-        "usernamehw.errorlens",
-        "pflannery.vscode-versionlens",
-        "kricsleo.vscode-package-json-inspector",
-        "chadonsom.auto-view-readme",
-        "donjayamanne.githistory",
-        "mhutchie.git-graph",
-        "github.vscode-github-actions",
-        "pkief.material-icon-theme"
-    ]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "drknoxy.eslint-disable-snippets",
+    "ms-python.black-formatter",
+    "aaron-bond.better-comments",
+    "ionutvmi.path-autocomplete",
+    "eamodio.gitlens",
+    "usernamehw.errorlens",
+    "legalfina.npm-version-lens",
+    "kricsleo.vscode-package-json-inspector",
+    "chadonsom.auto-view-readme",
+    "donjayamanne.githistory",
+    "mhutchie.git-graph",
+    "github.vscode-github-actions",
+    "pkief.material-icon-theme"
+  ]
 }


### PR DESCRIPTION
## Recommend npm-version-lens

This PR updates `.vscode/extensions.json` to recommend [**npm-version-lens**](https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens) in place of the following extension(s):

- `pflannery.vscode-versionlens`

### Why?

**npm-version-lens** provides:
- Color-coded version indicators directly in `package.json`
- One-click version updates via an inline dropdown
- Inlay hints showing the latest available version

It is actively maintained and lightweight.

Marketplace: https://marketplace.visualstudio.com/items?itemName=Legalfina.npm-version-lens